### PR TITLE
Update iiletter.cls

### DIFF
--- a/inputs/iiletter.cls
+++ b/inputs/iiletter.cls
@@ -27,7 +27,7 @@
 \RequirePackage[brazilian]{babel}
 \RequirePackage{graphicx}
     \RequirePackage{keyval}
-\RequirePackage{fixltx2e}
+%\RequirePackage{fixltx2e}
 \RequirePackage{epstopdf}
 \RequirePackage{iidefs}
 


### PR DESCRIPTION
\RequirePackage{fixltx2e} is no longer needed as fixltx2e is provided by default